### PR TITLE
Make v0.js think localhost is trusted using puppeteer

### DIFF
--- a/example/test/csp.test.js
+++ b/example/test/csp.test.js
@@ -1,11 +1,9 @@
 const { loadAMP } = require('./util/loader');
 
 test('AMP iframe uses CSP', async () => {
-  const { page, iframe } = await loadAMP();
-  await page.setRequestInterception(true);
-  page.on('request', req => {
-    expect(req.url().startsWith('https://evil.example/')).toBeFalsy();
-    req.continue();
+  const { page, iframe, requests } = await loadAMP();
+  requests.on('request', req => {
+    expect(req.url.startsWith('https://evil.example/')).toBeFalsy();
   });
 
   await iframe.waitForSelector('html.i-amphtml-iframed');

--- a/example/test/util/loader.js
+++ b/example/test/util/loader.js
@@ -1,4 +1,9 @@
+const fetch = require('node-fetch');
+const EventEmitter = require('events');
+
 const IFRAME_SELECTOR = '#viewer > iframe';
+const RUNTIME_URL = 'https://cdn.ampproject.org/v0.js';
+const RUNTIME_CODE = loadRuntime();
 
 /**
  * Loads the viewer home page using Puppeteer and injects custom AMP code into
@@ -8,6 +13,8 @@ const IFRAME_SELECTOR = '#viewer > iframe';
  * @return {!Object} Whether the content type is accepted
  */
 async function loadAMP(code = '') {
+  const requests = await interceptRequests(page);
+
   await page.evaluateOnNewDocument(code => {
     window.ampCode = code;
   }, code);
@@ -19,7 +26,40 @@ async function loadAMP(code = '') {
     iframeElement,
     iframe,
     page,
+    requests
   };
+}
+
+async function interceptRequests(page) {
+  const runtimeCode = await RUNTIME_CODE;
+  await page.setRequestInterception(true);
+  const requests = new EventEmitter();
+  page.removeAllListeners('request');
+  page.on('request', req => {
+    requests.emit('request', {
+      url: req.url()
+    });
+
+    if (req.url() === RUNTIME_URL) {
+      req.respond({
+        status: 200,
+        contentType: 'text/javascript',
+        body: runtimeCode,
+      });
+      return;
+    }
+    req.continue();
+  });
+  return requests;
+}
+
+async function loadRuntime() {
+  const code = await (await fetch(RUNTIME_URL)).text();
+
+  // Hacky way to ensure localhost is trusted in our tests.
+  // URLs starting with the "x-thread:" protocol are always trusted. By changing
+  // to "http:", we allow http://localhost to be trusted.
+  return code.replace('x-thread:', 'http:');
 }
 
 module.exports = { loadAMP };


### PR DESCRIPTION
This is a very hacky approach, but easiest one that doesn't require rebuilding v0.js locally to run tests that require a trusted viewer.